### PR TITLE
Add chat app with login and admin settings

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,31 @@
+import { openai } from '@ai-sdk/openai';
+import { anthropic } from '@ai-sdk/anthropic';
+import { convertToCoreMessages, streamText } from 'ai';
+import { findUser } from '@/lib/users';
+
+export const runtime = 'edge';
+
+export async function POST(req: Request) {
+  const { provider, model, messages } = await req.json();
+  const username = req.headers.get('authorization') || '';
+  const user = findUser(username);
+  if (!user || !user.approved) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  const apiKey = provider === 'anthropic' ? user.claudeKey : user.openaiKey;
+  if (!apiKey) {
+    return new Response('Missing API key', { status: 400 });
+  }
+  const modelFn = provider === 'anthropic'
+    ? anthropic(model, { apiKey })
+    : openai(model, { apiKey });
+  const result = await streamText({
+    model: modelFn,
+    messages: convertToCoreMessages(messages),
+    system: 'You are a helpful AI assistant',
+  });
+  const text = await result.text;
+  return new Response(JSON.stringify({ reply: text }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,16 @@
+import { findUser } from '@/lib/users';
+
+export async function POST(req: Request) {
+  const { username, password } = await req.json();
+  const user = findUser(username);
+  if (!user || user.password !== password) {
+    return new Response(JSON.stringify({ error: 'Invalid credentials' }), { status: 401 });
+  }
+  if (!user.approved) {
+    return new Response(JSON.stringify({ error: 'Not approved' }), { status: 403 });
+  }
+  return new Response(
+    JSON.stringify({ token: user.username, role: user.role }),
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+}

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,0 +1,15 @@
+import { addUser, findUser } from '@/lib/users';
+
+export async function POST(req: Request) {
+  const { username, password } = await req.json();
+  if (!username || !password) {
+    return new Response(JSON.stringify({ error: 'Missing fields' }), { status: 400 });
+  }
+  if (findUser(username)) {
+    return new Response(JSON.stringify({ error: 'User exists' }), { status: 400 });
+  }
+  addUser(username, password);
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,27 @@
+import { findUser, setApiKeys } from '@/lib/users';
+
+export async function GET(req: Request) {
+  const username = req.headers.get('authorization') || '';
+  const user = findUser(username);
+  if (!user) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  const { openaiKey = '', claudeKey = '', role, approved } = user;
+  return new Response(
+    JSON.stringify({ openaiKey, claudeKey, role, approved }),
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+export async function POST(req: Request) {
+  const username = req.headers.get('authorization') || '';
+  const user = findUser(username);
+  if (!user) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  const { openaiKey, claudeKey } = await req.json();
+  setApiKeys(username, openaiKey, claudeKey);
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,25 @@
+import { users, approveUser, findUser } from '@/lib/users';
+
+export async function GET(req: Request) {
+  const username = req.headers.get('authorization') || '';
+  const user = findUser(username);
+  if (!user || user.role !== 'admin') {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  return new Response(JSON.stringify(users), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export async function POST(req: Request) {
+  const username = req.headers.get('authorization') || '';
+  const admin = findUser(username);
+  if (!admin || admin.role !== 'admin') {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  const { user: target } = await req.json();
+  approveUser(target);
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+type Message = { role: 'user' | 'assistant'; content: string };
+
+export default function ChatPage() {
+  const router = useRouter();
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [provider, setProvider] = useState<'openai' | 'anthropic'>('openai');
+  const [model, setModel] = useState('gpt-4o');
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      router.push('/login');
+    }
+  }, [router]);
+
+  const sendMessage = async () => {
+    const token = localStorage.getItem('token') || '';
+    const newMessages = [...messages, { role: 'user', content: input }];
+    setMessages(newMessages);
+    setInput('');
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token,
+      },
+      body: JSON.stringify({ provider, model, messages: newMessages }),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setMessages([...newMessages, { role: 'assistant', content: data.reply }]);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex gap-2">
+        <select
+          value={provider}
+          onChange={(e) => {
+            const val = e.target.value as 'openai' | 'anthropic';
+            setProvider(val);
+            setModel(val === 'anthropic' ? 'claude-3-5-sonnet-20240620' : 'gpt-4o');
+          }}
+          className="border p-1"
+        >
+          <option value="openai">ChatGPT</option>
+          <option value="anthropic">Claude</option>
+        </select>
+        <input
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          className="border p-1 flex-1"
+        />
+        <a href="/settings" className="underline text-sm self-center">
+          Settings
+        </a>
+      </div>
+      <div className="border p-2 h-80 overflow-y-auto">
+        {messages.map((m, i) => (
+          <div key={i} className="mb-2">
+            <b>{m.role}:</b> {m.content}
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="border p-1 flex-1"
+          placeholder="Say something"
+        />
+        <button onClick={sendMessage} className="bg-blue-500 text-white px-3">
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function LoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      setError(data.error || 'Login failed');
+      return;
+    }
+    localStorage.setItem('token', data.token);
+    localStorage.setItem('role', data.role);
+    router.push('/chat');
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2 border p-4 rounded">
+        <h1 className="text-xl">Login</h1>
+        <input
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Username"
+          className="border p-1"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="border p-1"
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1">
+          Login
+        </button>
+        <a href="/register" className="text-blue-500 text-sm">
+          Register
+        </a>
+      </form>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,48 +1,5 @@
-import Link from "next/link";
+import { redirect } from 'next/navigation';
 
 export default function Home() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-8">
-      <div>
-        <h2 className="text-2xl font-semibold text-center border p-4 font-mono rounded-md">
-          Get started by choosing a template path from the /paths/ folder.
-        </h2>
-      </div>
-      <div>
-        <h1 className="text-6xl font-bold text-center">Make anything you imagine 🪄</h1>
-        <h2 className="text-2xl text-center font-light text-gray-500 pt-4">
-          This whole page will be replaced when you run your template path.
-        </h2>
-      </div>
-      <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <div className="border rounded-lg p-6 hover:bg-gray-100 transition-colors">
-          <h3 className="text-xl font-semibold">AI Chat App</h3>
-          <p className="mt-2 text-sm text-gray-600">
-            An intelligent conversational app powered by AI models, featuring real-time responses
-            and seamless integration with Next.js and various AI providers.
-          </p>
-        </div>
-        <div className="border rounded-lg p-6 hover:bg-gray-100 transition-colors">
-          <h3 className="text-xl font-semibold">AI Image Generation App</h3>
-          <p className="mt-2 text-sm text-gray-600">
-            Create images from text prompts using AI, powered by the Replicate API and Next.js.
-          </p>
-        </div>
-        <div className="border rounded-lg p-6 hover:bg-gray-100 transition-colors">
-          <h3 className="text-xl font-semibold">Social Media App</h3>
-          <p className="mt-2 text-sm text-gray-600">
-            A feature-rich social platform with user profiles, posts, and interactions using
-            Firebase and Next.js.
-          </p>
-        </div>
-        <div className="border rounded-lg p-6 hover:bg-gray-100 transition-colors">
-          <h3 className="text-xl font-semibold">Voice Notes App</h3>
-          <p className="mt-2 text-sm text-gray-600">
-            A voice-based note-taking app with real-time transcription using Deepgram API, 
-            Firebase integration for storage, and a clean, simple interface built with Next.js.
-          </p>
-        </div>
-      </div>
-    </main>
-  );
+  redirect('/login');
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function RegisterPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setMessage('Registered. Await approval.');
+    } else {
+      setMessage(data.error || 'Registration failed');
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2 border p-4 rounded">
+        <h1 className="text-xl">Register</h1>
+        <input
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Username"
+          className="border p-1"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="border p-1"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1">
+          Register
+        </button>
+        {message && <p className="text-sm">{message}</p>}
+        <a href="/login" className="text-blue-500 text-sm">
+          Login
+        </a>
+      </form>
+    </div>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface UserInfo {
+  openaiKey: string;
+  claudeKey: string;
+  role: string;
+  approved: boolean;
+}
+
+export default function SettingsPage() {
+  const router = useRouter();
+  const [info, setInfo] = useState<UserInfo | null>(null);
+  const [users, setUsers] = useState<any[]>([]);
+  const [status, setStatus] = useState('');
+  const [role, setRole] = useState('');
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      router.push('/login');
+      return;
+    }
+    setRole(localStorage.getItem('role') || '');
+    fetch('/api/settings', { headers: { Authorization: token } })
+      .then((res) => res.json())
+      .then((data) => setInfo(data));
+    if (localStorage.getItem('role') === 'admin') {
+      fetch('/api/users', { headers: { Authorization: token } })
+        .then((res) => res.json())
+        .then((data) => setUsers(data));
+    }
+  }, [router]);
+
+  const saveKeys = async () => {
+    if (!info) return;
+    const token = localStorage.getItem('token') || '';
+    const res = await fetch('/api/settings', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token,
+      },
+      body: JSON.stringify({ openaiKey: info.openaiKey, claudeKey: info.claudeKey }),
+    });
+    if (res.ok) setStatus('Saved');
+  };
+
+  const approve = async (username: string) => {
+    const token = localStorage.getItem('token') || '';
+    await fetch('/api/users', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token,
+      },
+      body: JSON.stringify({ user: username }),
+    });
+    const list = await fetch('/api/users', { headers: { Authorization: token } });
+    setUsers(await list.json());
+  };
+
+  if (!info) return null;
+
+  return (
+    <div className="p-4 space-y-4">
+      <div>
+        <h1 className="text-xl mb-2">API Keys</h1>
+        <input
+          value={info.openaiKey}
+          onChange={(e) => setInfo({ ...info, openaiKey: e.target.value })}
+          placeholder="OpenAI API Key"
+          className="border p-1 w-full mb-2"
+        />
+        <input
+          value={info.claudeKey}
+          onChange={(e) => setInfo({ ...info, claudeKey: e.target.value })}
+          placeholder="Claude API Key"
+          className="border p-1 w-full mb-2"
+        />
+        <button onClick={saveKeys} className="bg-blue-500 text-white px-2 py-1">
+          Save
+        </button>
+        {status && <span className="ml-2 text-sm">{status}</span>}
+      </div>
+      {role === 'admin' && (
+        <div>
+          <h2 className="text-lg mb-2">User Management</h2>
+          {users.filter((u) => !u.approved).map((u) => (
+            <div key={u.username} className="flex gap-2 mb-1">
+              <span>{u.username}</span>
+              <button
+                onClick={() => approve(u.username)}
+                className="bg-green-500 text-white px-2"
+              >
+                Approve
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -1,0 +1,37 @@
+export interface User {
+  username: string;
+  password: string;
+  approved: boolean;
+  role: 'admin' | 'user';
+  openaiKey?: string;
+  claudeKey?: string;
+}
+
+const users: User[] = [
+  { username: 'Admin', password: 'Admin', approved: true, role: 'admin' },
+];
+
+export function findUser(username: string) {
+  return users.find(u => u.username === username);
+}
+
+export function addUser(username: string, password: string) {
+  users.push({ username, password, approved: false, role: 'user' });
+}
+
+export function approveUser(username: string) {
+  const user = findUser(username);
+  if (user) {
+    user.approved = true;
+  }
+}
+
+export function setApiKeys(username: string, openaiKey?: string, claudeKey?: string) {
+  const user = findUser(username);
+  if (user) {
+    user.openaiKey = openaiKey;
+    user.claudeKey = claudeKey;
+  }
+}
+
+export { users };


### PR DESCRIPTION
## Summary
- implement simple auth system with user approval and API key storage
- add chat interface supporting ChatGPT and Claude
- include admin-only user management and default Admin/Admin account

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ad76370748332855aec52c875dd9a