### PR TITLE
Fix provider API key handling and message typing

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,5 +1,5 @@
-import { openai } from '@ai-sdk/openai';
-import { anthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createAnthropic } from '@ai-sdk/anthropic';
 import { convertToCoreMessages, streamText } from 'ai';
 import { findUser } from '@/lib/users';
 
@@ -17,8 +17,8 @@ export async function POST(req: Request) {
     return new Response('Missing API key', { status: 400 });
   }
   const modelFn = provider === 'anthropic'
-    ? anthropic(model, { apiKey })
-    : openai(model, { apiKey });
+    ? createAnthropic({ apiKey })(model)
+    : createOpenAI({ apiKey })(model);
   const result = await streamText({
     model: modelFn,
     messages: convertToCoreMessages(messages),

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -18,24 +18,26 @@ export default function ChatPage() {
     }
   }, [router]);
 
-  const sendMessage = async () => {
-    const token = localStorage.getItem('token') || '';
-    const newMessages = [...messages, { role: 'user', content: input }];
-    setMessages(newMessages);
-    setInput('');
-    const res = await fetch('/api/chat', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: token,
-      },
-      body: JSON.stringify({ provider, model, messages: newMessages }),
-    });
-    const data = await res.json();
-    if (res.ok) {
-      setMessages([...newMessages, { role: 'assistant', content: data.reply }]);
-    }
-  };
+    const sendMessage = async () => {
+      const token = localStorage.getItem('token') || '';
+      const userMessage: Message = { role: 'user', content: input };
+      const newMessages: Message[] = [...messages, userMessage];
+      setMessages(newMessages);
+      setInput('');
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: token,
+        },
+        body: JSON.stringify({ provider, model, messages: newMessages }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        const assistantMessage: Message = { role: 'assistant', content: data.reply };
+        setMessages([...newMessages, assistantMessage]);
+      }
+    };
 
   return (
     <div className="p-4 space-y-4">


### PR DESCRIPTION
## Summary
- Instantiate provider clients with user API keys in chat route
- Define chat messages with explicit types to satisfy Message union

## Testing
- `npm test` (fails: Missing script "test")
- `OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689adb9d1a78833295f480ef3469fd8e