### PR TITLE
feat: handle missing OpenAI key

### DIFF
--- a/src/app/api/openai/chat/route.ts
+++ b/src/app/api/openai/chat/route.ts
@@ -1,9 +1,15 @@
-import { openai } from "@ai-sdk/openai";
+import { createOpenAI } from "@ai-sdk/openai";
 import { convertToCoreMessages, streamText } from "ai";
 
 export const runtime = "edge";
 
 export async function POST(req: Request) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return new Response("Missing OpenAI API key", { status: 400 });
+  }
+
+  const openai = createOpenAI({ apiKey });
   const { messages } = await req.json();
   const result = await streamText({
     model: openai("gpt-4o"),

--- a/src/app/api/openai/transcribe/route.ts
+++ b/src/app/api/openai/transcribe/route.ts
@@ -1,10 +1,19 @@
 import { NextResponse } from "next/server";
 import fs from "fs";
 import OpenAI from "openai";
-
-const openai = new OpenAI();
+import { findUser } from "@/lib/users";
 
 export async function POST(req: Request) {
+  const username = req.headers.get("authorization") || "";
+  const user = findUser(username);
+  if (!user?.openaiKey) {
+    return NextResponse.json(
+      { error: "Missing OpenAI API key" },
+      { status: 400 }
+    );
+  }
+
+  const openai = new OpenAI({ apiKey: user.openaiKey });
   const body = await req.json();
 
   const base64Audio = body.audio;


### PR DESCRIPTION
## Summary
- avoid build failures by creating OpenAI client only when a user-provided key is present
- guard OpenAI chat endpoint with explicit key check

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ade319b58833299a4333648f25318