### PR TITLE
Refine image handling components

### DIFF
--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -37,9 +37,8 @@ export default function ImageUpload({ onImageChange }: ImageUploadProps) {
           <Image
             src={imagePreview}
             alt="Preview"
-            layout="fill"
-            objectFit="cover"
-            className="rounded-lg"
+            fill
+            className="object-cover rounded-lg"
           />
           <button
             type="button"

--- a/src/components/SignInWithGoogle.tsx
+++ b/src/components/SignInWithGoogle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useAuth } from '../lib/hooks/useAuth';
 
 export default function SignInWithGoogle() {
@@ -10,7 +11,13 @@ export default function SignInWithGoogle() {
       onClick={signInWithGoogle}
       className="flex items-center justify-center bg-white text-gray-700 font-semibold py-2 px-4 rounded-full border border-gray-300 hover:bg-gray-100 transition duration-300 ease-in-out"
     >
-      <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" alt="Google logo" className="w-6 h-6 mr-2" />
+      <Image
+        src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg"
+        alt="Google logo"
+        width={24}
+        height={24}
+        className="w-6 h-6 mr-2"
+      />
       Sign in with Google
     </button>
   );

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useDeepgram } from '../lib/contexts/DeepgramContext';
 import { addDocument } from '../lib/firebase/firebaseUtils';
 import { motion } from 'framer-motion';


### PR DESCRIPTION
## Summary
- modernize ImageUpload to use Next.js `fill` API instead of deprecated props
- switch Google sign-in button to Next.js `<Image>` for optimized loading
- clean up VoiceRecorder by removing unused `useEffect` import

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ade4a1b9c833280a21b62497b955b